### PR TITLE
Bump version to 0.7.5 and update ruff-pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
     hooks:
       - id: pyproject-fmt
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.0
+    rev: v0.11.1
     hooks:
       - id: ruff
         args: [--fix]

--- a/README.rst
+++ b/README.rst
@@ -45,7 +45,7 @@ https://bhooi.github.io/projects/fraudar/index.html.
    :target: https://codeclimate.com/github/rgmining/fraudar/maintainability
 .. |Test Coverage| image:: https://api.codeclimate.com/v1/badges/4c4c3df79b33f65b77cd/test_coverage
    :target: https://codeclimate.com/github/rgmining/fraudar/test_coverage
-.. |Release| image:: https://img.shields.io/badge/release-0.7.4-brightgreen.svg
+.. |Release| image:: https://img.shields.io/badge/release-0.7.5-brightgreen.svg
    :target: https://pypi.org/project/rgmining-fraudar/
 .. |Logo| image:: https://rgmining.github.io/fraudar/_static/image.png
    :target: https://rgmining.github.io/fraudar/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [ "poetry-core>=1" ]
 
 [project]
 name = "rgmining-fraudar"
-version = "0.7.4"
+version = "0.7.5"
 description = "A wrapper of Fraudar algorithm for Review graph mining project"
 readme = "README.rst"
 keywords = [ "algorithm", "fraudar", "graph", "kdd", "mining", "review" ]
@@ -79,7 +79,7 @@ omit = [ "fraudar/export/*" ]
 exclude_lines = [ "\\.{3}" ]
 
 [tool.bumpversion]
-current_version = "0.7.4"
+current_version = "0.7.5"
 commit = true
 pre_commit_hooks = [
   "poetry lock",


### PR DESCRIPTION
### Description

- Bumped project version from `0.7.4` to `0.7.5`.
- Updated `ruff-pre-commit` hook from `v0.11.0` to `v0.11.1` in the pre-commit configuration for compatibility with the latest changes and bug fixes. 

No functional changes to the project codebase were introduced.